### PR TITLE
メールのチーム名が異なるバグを修正

### DIFF
--- a/app/Http/Controllers/User/TeamController.php
+++ b/app/Http/Controllers/User/TeamController.php
@@ -57,7 +57,6 @@ class TeamController extends Controller
         $teamId = $teamIdData['id'];
         $teamName = $this->team
                          ->find($teamId)
-                         ->first()
                          ->name;
         $this->invite($input['emails'], Auth::user()->name, $teamName, $teamId);
         return redirect()->route('team.show', $teamId);


### PR DESCRIPTION
招待メールのチーム名がチームidが1のものになるバグを修正